### PR TITLE
handle error in main

### DIFF
--- a/cmd/ktctl/main.go
+++ b/cmd/ktctl/main.go
@@ -31,8 +31,9 @@ func main() {
 	ch := command.SetUpCloseHandler(options)
 	err := app.Run(os.Args)
 	if err != nil {
-		log.Info().Msg(err.Error())
+		log.Error().Msg(err.Error())
 		command.CleanupWorkspace(options)
+		os.Exit(-1)
 	}
 
 	if util.IsHelpCommand(os.Args) {

--- a/pkg/kt/command/commands.go
+++ b/pkg/kt/command/commands.go
@@ -76,8 +76,7 @@ func newConnectCommand(options *options.DaemonOptions) cli.Command {
 				zerolog.SetGlobalLevel(zerolog.DebugLevel)
 			}
 			action := Action{}
-			action.Connect(options)
-			return nil
+			return action.Connect(options)
 		},
 	}
 }
@@ -100,8 +99,7 @@ func newExchangeCommand(options *options.DaemonOptions) cli.Command {
 			}
 
 			action := Action{}
-			action.Exchange(c.Args().First(), options)
-			return nil
+			return action.Exchange(c.Args().First(), options)
 		},
 	}
 }

--- a/pkg/kt/connect/mesh.go
+++ b/pkg/kt/connect/mesh.go
@@ -16,7 +16,7 @@ import (
 func (c *Connect) Mesh(swap string, options *options.DaemonOptions, clientset *kubernetes.Clientset, labels map[string]string) (workload string, err error) {
 	workload, podIP, podName, err := c.createMeshShadown(swap, clientset, labels, options.Namespace, options.Image)
 	if err != nil {
-		panic(err.Error())
+		return
 	}
 	options.RuntimeOptions.Shadow = workload
 	err = remotePortForward(options.MeshOptions.Expose, options.KubeConfig, options.Namespace, podName, podIP, options.Debug)


### PR DESCRIPTION
Make sure all errors are return to main, and get handled.
e.g. If you have no sshuttle installed locally, kt should print the error and exit.