### PR TITLE
improvement : use Informer to waitPodReady

### DIFF
--- a/cmd/ktctl/.gitignore
+++ b/cmd/ktctl/.gitignore
@@ -1,0 +1,2 @@
+ktctl
+ktctl.exe

--- a/cmd/ktctl/Makefile
+++ b/cmd/ktctl/Makefile
@@ -1,0 +1,7 @@
+go_build:
+	go build
+
+test: go_build prune_test
+	
+prune_test:
+	sudo ./ktctl connect --method=vpn

--- a/pkg/kt/cluster/kubernetes.go
+++ b/pkg/kt/cluster/kubernetes.go
@@ -1,6 +1,7 @@
 package cluster
 
 import (
+	"errors"
 	"time"
 
 	clusterWatcher "github.com/alibaba/kt-connect/pkg/apiserver/cluster"
@@ -8,9 +9,14 @@ import (
 	"github.com/rs/zerolog/log"
 	appsv1 "k8s.io/api/apps/v1"
 	apiv1 "k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/selection"
+	"k8s.io/apimachinery/pkg/util/runtime"
+	"k8s.io/client-go/informers"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/tools/cache"
 	"k8s.io/client-go/tools/clientcmd"
 )
 
@@ -77,7 +83,8 @@ func CreateShadow(
 	}
 	log.Info().Msgf("Deploying shadow deployment %s in namespace %s\n", result.GetObjectMeta().GetName(), namespace)
 
-	pod, err := waitPodReady(namespace, name, clientset)
+	// pod, err := waitPodReady(namespace, name, clientset)
+	pod, err := waitPodReadyUsingInformer(namespace, name, clientset)
 	if err != nil {
 		return
 	}
@@ -87,6 +94,7 @@ func CreateShadow(
 	return
 }
 
+// Deprecated : this implement is not "golang style"
 func waitPodReady(namespace, name string, clientset *kubernetes.Clientset) (pod apiv1.Pod, err error) {
 	pod = apiv1.Pod{}
 	for {
@@ -112,6 +120,89 @@ func waitPodReady(namespace, name string, clientset *kubernetes.Clientset) (pod 
 	}
 	log.Info().Msg("Shadow is ready.")
 	return
+}
+
+func waitPodReadyUsingInformer(namespace, name string, clientset *kubernetes.Clientset) (pod apiv1.Pod, err error) {
+	pod = apiv1.Pod{}
+	// sharedInformerFactory:=informers.SharedInformerOption()
+	option := informers.WithNamespace(namespace)
+	factory := informers.NewSharedInformerFactoryWithOptions(clientset, 0, option)
+	podInformer := factory.Core().V1().Pods()
+	podLabels := labels.NewSelector()
+	log.Info().Msgf("pod label: kt=%s", name)
+	labelKeys := []string{
+		"kt",
+	}
+	requirement, err := labels.NewRequirement(labelKeys[0], selection.Equals, []string{name})
+	if err != nil {
+		return
+	}
+	podLabels.Add(*requirement)
+	// Kubernetes serves an utility to handle API crashes
+	defer runtime.HandleCrash()
+	stopSignal := make(chan struct{})
+	defer close(stopSignal)
+	go factory.Start(stopSignal)
+	if !cache.WaitForNamedCacheSync("attach detach", stopSignal,
+		podInformer.Informer().HasSynced) {
+		err = errors.New("Error waiting for the informer caches to sync")
+		if err != nil {
+			return pod, err
+		}
+	}
+	pods, err := podInformer.Lister().Pods(namespace).List(podLabels)
+	if err != nil {
+		return pod, err
+	}
+	log.Info().Msg("podInformer init")
+	getTargetPod := func(podList []*v1.Pod) *v1.Pod {
+		// log.Info().Msgf("len(podList):%d", len(podList))
+		for _, p := range podList {
+			if len(p.Labels) <= 0 {
+				// almost impossible
+				continue
+			}
+			item, containKey := p.Labels[labelKeys[0]]
+			if !containKey || item != name {
+				continue
+			}
+			return p
+		}
+		return nil
+	}
+	wait := func(podName string) {
+		time.Sleep(time.Second)
+		if len(podName) >= 0 {
+			log.Info().Msgf("pod: %s is running,but not ready", podName)
+			return
+		}
+		log.Info().Msg("Shadow Pods not ready......")
+	}
+wait_loop:
+	for {
+		hasRunningPod := len(pods) > 0
+		var podName string
+		if hasRunningPod {
+			// podLister do not support FieldSelector
+			// https://github.com/kubernetes/client-go/issues/604
+			p := getTargetPod(pods)
+			if p != nil {
+				if p.Status.Phase == "Running" {
+					pod = *p
+					log.Info().Msgf("Shadow pod: %s is ready.", pod.Name)
+					break wait_loop
+				}
+				podName = p.Name
+			}
+		}
+		wait(podName)
+		pods, err = podInformer.Lister().Pods(namespace).List(podLabels)
+		if err != nil {
+			return pod, err
+		}
+	}
+	<-stopSignal
+	return pod, nil
 }
 
 func generatorDeployment(namespace, name string, labels map[string]string, image string) *appsv1.Deployment {


### PR DESCRIPTION
TEST result:
```

12:40PM INF Connect Start At 85633
12:40PM INF Client address 192.168.10.42
12:40PM INF Deploying shadow deployment kt-connect-daemon-zeprd in namespace default

12:40PM INF pod label: kt=kt-connect-daemon-zeprd
I0303 12:40:30.938477   85633 shared_informer.go:197] Waiting for caches to sync for attach detach
I0303 12:40:31.242520   85633 shared_informer.go:204] Caches are synced for attach detach 
12:40PM INF podInformer init
12:40PM INF pod: kt-connect-daemon-zeprd-5fd568db8b-c7v98 is running,but not ready
12:40PM INF pod: kt-connect-daemon-zeprd-5fd568db8b-c7v98 is running,but not ready
12:40PM INF Shadow pod: kt-connect-daemon-zeprd-5fd568db8b-c7v98 is ready.
^C12:40PM INF - Terminal And Clean Workspace

12:40PM INF - Start Clean Workspace

12:40PM INF - Remove pid /Users/charles/.ktctl/pid
12:40PM INF - Drop hosts successful.
12:40PM INF - Start Clean Shadow kt-connect-daemon-zeprd
12:40PM INF - Successful Clean Shadow kt-connect-daemon-zeprd
12:40PM INF - Successful Clean Up Workspace
```