### PR TITLE
Support shareShadow option for connect

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,6 +45,9 @@ build-shadow-base:
 build-shadow:
 	GOARCH=amd64 GOOS=linux go build -gcflags "all=-N -l" -o artifacts/shadow/shadow-linux-amd64 cmd/shadow/main.go
 	docker build -t $(PREFIX)/$(SHADOW_IMAGE):$(TAG) -f docker/shadow/Dockerfile .
+
+# release shadow
+release-shadow:
 	docker push $(PREFIX)/$(SHADOW_IMAGE):$(TAG)
 
 # dlv for debug

--- a/Makefile
+++ b/Makefile
@@ -45,9 +45,6 @@ build-shadow-base:
 build-shadow:
 	GOARCH=amd64 GOOS=linux go build -gcflags "all=-N -l" -o artifacts/shadow/shadow-linux-amd64 cmd/shadow/main.go
 	docker build -t $(PREFIX)/$(SHADOW_IMAGE):$(TAG) -f docker/shadow/Dockerfile .
-
-# release shadow
-release-shadow:
 	docker push $(PREFIX)/$(SHADOW_IMAGE):$(TAG)
 
 # dlv for debug

--- a/bin/build-shadow
+++ b/bin/build-shadow
@@ -2,4 +2,3 @@
 TAG=$(echo $TRAVIS_BRANCH | sed "s/\//-/")
 TAG=${TAG:-latest}
 docker build -t registry.cn-hangzhou.aliyuncs.com/rdc-incubator/kt-connect-shadow:$TAG -f docker/shadow/Dockerfile . && \
-docker push registry.cn-hangzhou.aliyuncs.com/rdc-incubator/kt-connect-shadow:$TAG

--- a/cmd/ktctl/main.go
+++ b/cmd/ktctl/main.go
@@ -37,7 +37,7 @@ func main() {
 	err := app.Run(os.Args)
 	if err != nil {
 		log.Error().Msg(err.Error())
-		command.CleanupWorkspace(context, options)
+		command.CleanupWorkspace(context, options, os.Args[0])
 		os.Exit(-1)
 	}
 

--- a/cmd/ktctl/main.go
+++ b/cmd/ktctl/main.go
@@ -37,7 +37,7 @@ func main() {
 	err := app.Run(os.Args)
 	if err != nil {
 		log.Error().Msg(err.Error())
-		command.CleanupWorkspace(context, options, os.Args[0])
+		command.CleanupWorkspace(context, options)
 		os.Exit(-1)
 	}
 

--- a/fake/kt/action/action_mock.go
+++ b/fake/kt/action/action_mock.go
@@ -5,11 +5,10 @@
 package action
 
 import (
-	reflect "reflect"
-
 	kt "github.com/alibaba/kt-connect/pkg/kt"
 	options "github.com/alibaba/kt-connect/pkg/kt/options"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockActionInterface is a mock of ActionInterface interface

--- a/fake/kt/cluster/kubernetes_mock.go
+++ b/fake/kt/cluster/kubernetes_mock.go
@@ -5,12 +5,11 @@
 package cluster
 
 import (
-	reflect "reflect"
-
 	util "github.com/alibaba/kt-connect/pkg/kt/util"
 	gomock "github.com/golang/mock/gomock"
 	v1 "k8s.io/api/apps/v1"
 	v10 "k8s.io/api/core/v1"
+	reflect "reflect"
 )
 
 // MockKubernetesInterface is a mock of KubernetesInterface interface
@@ -150,10 +149,10 @@ func (mr *MockKubernetesInterfaceMockRecorder) ClusterCrids(podCIDR interface{})
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ClusterCrids", reflect.TypeOf((*MockKubernetesInterface)(nil).ClusterCrids), podCIDR)
 }
 
-// CreateShadow mocks base method
-func (m *MockKubernetesInterface) CreateShadow(name, namespace, image string, labels map[string]string, debug bool) (string, string, string, *util.SSHCredential, error) {
+// GetOrCreateShadow mocks base method
+func (m *MockKubernetesInterface) GetOrCreateShadow(name, namespace, image string, labels map[string]string, debug, reuseShadow bool) (string, string, string, *util.SSHCredential, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "CreateShadow", name, namespace, image, labels, debug)
+	ret := m.ctrl.Call(m, "GetOrCreateShadow", name, namespace, image, labels, debug, reuseShadow)
 	ret0, _ := ret[0].(string)
 	ret1, _ := ret[1].(string)
 	ret2, _ := ret[2].(string)
@@ -162,10 +161,10 @@ func (m *MockKubernetesInterface) CreateShadow(name, namespace, image string, la
 	return ret0, ret1, ret2, ret3, ret4
 }
 
-// CreateShadow indicates an expected call of CreateShadow
-func (mr *MockKubernetesInterfaceMockRecorder) CreateShadow(name, namespace, image, labels, debug interface{}) *gomock.Call {
+// GetOrCreateShadow indicates an expected call of GetOrCreateShadow
+func (mr *MockKubernetesInterfaceMockRecorder) GetOrCreateShadow(name, namespace, image, labels, debug, reuseShadow interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateShadow", reflect.TypeOf((*MockKubernetesInterface)(nil).CreateShadow), name, namespace, image, labels, debug)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreateShadow", reflect.TypeOf((*MockKubernetesInterface)(nil).GetOrCreateShadow), name, namespace, image, labels, debug, reuseShadow)
 }
 
 // CreateService mocks base method
@@ -181,4 +180,34 @@ func (m *MockKubernetesInterface) CreateService(name, namespace string, port int
 func (mr *MockKubernetesInterfaceMockRecorder) CreateService(name, namespace, port, labels interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateService", reflect.TypeOf((*MockKubernetesInterface)(nil).CreateService), name, namespace, port, labels)
+}
+
+// GetDeployment mocks base method
+func (m *MockKubernetesInterface) GetDeployment(name, namespace string) (*v1.Deployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetDeployment", name, namespace)
+	ret0, _ := ret[0].(*v1.Deployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetDeployment indicates an expected call of GetDeployment
+func (mr *MockKubernetesInterfaceMockRecorder) GetDeployment(name, namespace interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetDeployment", reflect.TypeOf((*MockKubernetesInterface)(nil).GetDeployment), name, namespace)
+}
+
+// UpdateDeployment mocks base method
+func (m *MockKubernetesInterface) UpdateDeployment(namespace string, deployment *v1.Deployment) (*v1.Deployment, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateDeployment", namespace, deployment)
+	ret0, _ := ret[0].(*v1.Deployment)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// UpdateDeployment indicates an expected call of UpdateDeployment
+func (mr *MockKubernetesInterfaceMockRecorder) UpdateDeployment(namespace, deployment interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateDeployment", reflect.TypeOf((*MockKubernetesInterface)(nil).UpdateDeployment), namespace, deployment)
 }

--- a/fake/kt/connect/connect_mock.go
+++ b/fake/kt/connect/connect_mock.go
@@ -5,11 +5,10 @@
 package connect
 
 import (
-	reflect "reflect"
-
 	exec "github.com/alibaba/kt-connect/pkg/kt/exec"
 	util "github.com/alibaba/kt-connect/pkg/kt/util"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockShadowInterface is a mock of ShadowInterface interface

--- a/fake/kt/exec/exec_mock.go
+++ b/fake/kt/exec/exec_mock.go
@@ -5,12 +5,11 @@
 package exec
 
 import (
-	reflect "reflect"
-
 	kubectl "github.com/alibaba/kt-connect/pkg/kt/exec/kubectl"
 	ssh "github.com/alibaba/kt-connect/pkg/kt/exec/ssh"
 	sshuttle "github.com/alibaba/kt-connect/pkg/kt/exec/sshuttle"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockCliInterface is a mock of CliInterface interface

--- a/fake/kt/exec/kubectl/kubectl_mock.go
+++ b/fake/kt/exec/kubectl/kubectl_mock.go
@@ -5,10 +5,9 @@
 package kubectl
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	exec "os/exec"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockCliInterface is a mock of CliInterface interface

--- a/fake/kt/exec/ssh/ssh_mock.go
+++ b/fake/kt/exec/ssh/ssh_mock.go
@@ -5,10 +5,9 @@
 package ssh
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	exec "os/exec"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockCliInterface is a mock of CliInterface interface

--- a/fake/kt/exec/sshuttle/sshuttle_mock.go
+++ b/fake/kt/exec/sshuttle/sshuttle_mock.go
@@ -5,10 +5,9 @@
 package sshuttle
 
 import (
+	gomock "github.com/golang/mock/gomock"
 	exec "os/exec"
 	reflect "reflect"
-
-	gomock "github.com/golang/mock/gomock"
 )
 
 // MockCliInterface is a mock of CliInterface interface

--- a/fake/kt/kt_mock.go
+++ b/fake/kt/kt_mock.go
@@ -5,12 +5,11 @@
 package kt
 
 import (
-	reflect "reflect"
-
 	cluster "github.com/alibaba/kt-connect/pkg/kt/cluster"
 	connect "github.com/alibaba/kt-connect/pkg/kt/connect"
 	exec "github.com/alibaba/kt-connect/pkg/kt/exec"
 	gomock "github.com/golang/mock/gomock"
+	reflect "reflect"
 )
 
 // MockCliInterface is a mock of CliInterface interface

--- a/pkg/kt/cluster/helper.go
+++ b/pkg/kt/cluster/helper.go
@@ -195,6 +195,9 @@ func deployment(namespace, name string, labels map[string]string, image, volume 
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
+					Annotations: map[string]string{
+						vars.RefCount: "1",
+					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{

--- a/pkg/kt/cluster/helper.go
+++ b/pkg/kt/cluster/helper.go
@@ -187,6 +187,9 @@ func deployment(namespace, name string, labels map[string]string, image, volume 
 			Name:      name,
 			Namespace: namespace,
 			Labels:    labels,
+			Annotations: map[string]string{
+				vars.RefCount: "1",
+			},
 		},
 		Spec: appV1.DeploymentSpec{
 			Selector: &metav1.LabelSelector{
@@ -195,9 +198,6 @@ func deployment(namespace, name string, labels map[string]string, image, volume 
 			Template: v1.PodTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: labels,
-					Annotations: map[string]string{
-						vars.RefCount: "1",
-					},
 				},
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{

--- a/pkg/kt/cluster/kubernetes.go
+++ b/pkg/kt/cluster/kubernetes.go
@@ -80,7 +80,7 @@ func (k *Kubernetes) GetOrCreateShadow(name, namespace, image string, labels map
 
 	if reuseShadow {
 		pod, generator, err2 := k.tryGetExistingShadowRelatedObjs(name, namespace, sshcm, privateKeyPath, labels)
-		if err2 == nil {
+		if err2 != nil {
 			err = err2
 			return
 		}

--- a/pkg/kt/cluster/kubernetes.go
+++ b/pkg/kt/cluster/kubernetes.go
@@ -146,13 +146,13 @@ func increaseRefCount(name string, clientSet kubernetes.Interface, namespace str
 	if err != nil {
 		return err
 	}
-	label := deployment.ObjectMeta.Labels
-	count, err := strconv.Atoi(label[vars.RefCount])
+	annotations := deployment.ObjectMeta.Annotations
+	count, err := strconv.Atoi(annotations[vars.RefCount])
 	if err != nil {
 		return err
 	}
 
-	deployment.ObjectMeta.Labels[vars.RefCount] = strconv.Itoa(count + 1)
+	deployment.ObjectMeta.Annotations[vars.RefCount] = strconv.Itoa(count + 1)
 
 	_, err = clientSet.AppsV1().Deployments(namespace).Update(deployment)
 	return err
@@ -171,8 +171,6 @@ func (k *Kubernetes) createShadowDeployment(labels map[string]string, sshcm stri
 	if err != nil {
 		return
 	}
-	labels[vars.RefCount] = "1"
-
 	clientSet := k.Clientset
 
 	labels["kt"] = sshcm

--- a/pkg/kt/cluster/kubernetes.go
+++ b/pkg/kt/cluster/kubernetes.go
@@ -139,7 +139,7 @@ func (k *Kubernetes) tryGetExistingShadowRelatedObjs(resourceMeta *ResourceMeta,
 	configMap, configMapError := cli.Get(sshKeyMeta.Sshcm, metav1.GetOptions{})
 
 	if configMapError != nil {
-		err = errors.New("Found shadow deployment but no configMap. Please delete the deployment #{shadow}")
+		err = errors.New("Found shadow deployment but no configMap. Please delete the deployment " + resourceMeta.Name)
 		return
 	}
 
@@ -184,6 +184,7 @@ func increaseRefCount(name string, clientSet kubernetes.Interface, namespace str
 	annotations := deployment.ObjectMeta.Annotations
 	count, err := strconv.Atoi(annotations[vars.RefCount])
 	if err != nil {
+		log.Error().Msgf("Failed to parse annotations[vars.RefCount] of deployment %s with value %s", name, annotations[vars.RefCount])
 		return err
 	}
 

--- a/pkg/kt/cluster/kubernetes_test.go
+++ b/pkg/kt/cluster/kubernetes_test.go
@@ -67,19 +67,19 @@ func TestKubernetes_CreateShadow(t *testing.T) {
 				Clientset: testclient.NewSimpleClientset(tt.objs...),
 			}
 
-			gotPodIP, gotPodName, gotSshcm, _, err := k.CreateShadow(tt.args.name, tt.args.namespace, tt.args.image, tt.args.labels, tt.args.debug)
+			gotPodIP, gotPodName, gotSshcm, _, err := k.GetOrCreateShadow(tt.args.name, tt.args.namespace, tt.args.image, tt.args.labels, tt.args.debug, false)
 			if (err != nil) != tt.wantErr {
-				t.Errorf("Kubernetes.CreateShadow() error = %v, wantErr %v", err, tt.wantErr)
+				t.Errorf("Kubernetes.GetOrCreateShadow() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if gotPodIP != tt.wantPodIP {
-				t.Errorf("Kubernetes.CreateShadow() gotPodIP = %v, want %v", gotPodIP, tt.wantPodIP)
+				t.Errorf("Kubernetes.GetOrCreateShadow() gotPodIP = %v, want %v", gotPodIP, tt.wantPodIP)
 			}
 			if gotPodName != tt.wantPodName {
-				t.Errorf("Kubernetes.CreateShadow() gotPodName = %v, want %v", gotPodName, tt.wantPodName)
+				t.Errorf("Kubernetes.GetOrCreateShadow() gotPodName = %v, want %v", gotPodName, tt.wantPodName)
 			}
 			if gotSshcm != tt.wantSshcm {
-				t.Errorf("Kubernetes.CreateShadow() gotSshcm = %v, want %v", gotSshcm, tt.wantSshcm)
+				t.Errorf("Kubernetes.GetOrCreateShadow() gotSshcm = %v, want %v", gotSshcm, tt.wantSshcm)
 			}
 		})
 	}

--- a/pkg/kt/cluster/types.go
+++ b/pkg/kt/cluster/types.go
@@ -28,8 +28,10 @@ type KubernetesInterface interface {
 	ScaleTo(deployment, namespace string, replicas *int32) (err error)
 	ServiceHosts(namespace string) (hosts map[string]string)
 	ClusterCrids(podCIDR string) (cidrs []string, err error)
-	CreateShadow(name, namespace, image string, labels map[string]string, debug bool) (podIP, podName, sshcm string, credential *util.SSHCredential, err error)
+	GetOrCreateShadow(name, namespace, image string, labels map[string]string, debug, reuseShadow bool) (podIP, podName, sshcm string, credential *util.SSHCredential, err error)
 	CreateService(name, namespace string, port int, labels map[string]string) (*coreV1.Service, error)
+	GetDeployment(name string, namespace string) (*appV1.Deployment, error)
+	UpdateDeployment(namespace string, deployment *appV1.Deployment) (*appV1.Deployment, error)
 }
 
 // Kubernetes implements KubernetesInterface

--- a/pkg/kt/command/connect_test.go
+++ b/pkg/kt/command/connect_test.go
@@ -69,7 +69,7 @@ func Test_shouldConnectToCluster(t *testing.T) {
 	kubernetes := fakeCluster.NewMockKubernetesInterface(ctl)
 	exec := exec.NewMockCliInterface(ctl)
 	shadow := fakeConnect.NewMockShadowInterface(ctl)
-	kubernetes.EXPECT().CreateShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("172.168.0.2", "shadowName", "sshcm", nil, nil).AnyTimes()
+	kubernetes.EXPECT().GetOrCreateShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return("172.168.0.2", "shadowName", "sshcm", nil, nil).AnyTimes()
 	kubernetes.EXPECT().ClusterCrids(gomock.Any()).Return([]string{"10.10.10.0/24"}, nil)
 
 	shadow.EXPECT().Outbound("shadowName", "172.168.0.2", gomock.Any(), []string{"10.10.10.0/24"}, gomock.Any()).Return(nil)
@@ -93,7 +93,7 @@ func Test_shouldConnectClusterFailWhenFailCreateShadow(t *testing.T) {
 
 	kubernetes := fakeCluster.NewMockKubernetesInterface(ctl)
 	shadow := fakeConnect.NewMockShadowInterface(ctl)
-	kubernetes.EXPECT().CreateShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("", "", "", nil, errors.New("")).AnyTimes()
+	kubernetes.EXPECT().GetOrCreateShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return("", "", "", nil, errors.New("")).AnyTimes()
 
 	ktctl.EXPECT().Shadow().AnyTimes().Return(shadow)
 	ktctl.EXPECT().Kubernetes().AnyTimes().Return(kubernetes, nil)
@@ -112,7 +112,7 @@ func Test_shouldConnectClusterFailWhenFailGetCrids(t *testing.T) {
 
 	kubernetes := fakeCluster.NewMockKubernetesInterface(ctl)
 	shadow := fakeConnect.NewMockShadowInterface(ctl)
-	kubernetes.EXPECT().CreateShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Return("172.168.0.2", "shadowName", "sshcm", nil, nil).AnyTimes()
+	kubernetes.EXPECT().GetOrCreateShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Return("172.168.0.2", "shadowName", "sshcm", nil, nil).AnyTimes()
 	kubernetes.EXPECT().ClusterCrids(gomock.Any()).Return([]string{}, errors.New("fail to get crid"))
 
 	ktctl.EXPECT().Shadow().AnyTimes().Return(shadow)

--- a/pkg/kt/command/exchange.go
+++ b/pkg/kt/command/exchange.go
@@ -51,7 +51,7 @@ func newExchangeCommand(cli kt.CliInterface, options *options.DaemonOptions, act
 
 //Exchange exchange kubernetes workload
 func (action *Action) Exchange(exchange string, cli kt.CliInterface, options *options.DaemonOptions) error {
-	ch := SetUpCloseHandler(cli, options)
+	ch := SetUpCloseHandler(cli, options, "exchange")
 
 	checkConnectRunning(options.RuntimeOptions.PidFile)
 
@@ -71,8 +71,7 @@ func (action *Action) Exchange(exchange string, cli kt.CliInterface, options *op
 
 	workload := app.GetName() + "-kt-" + strings.ToLower(util.RandomString(5))
 
-	podIP, podName, sshcm, credential, err := kubernetes.CreateShadow(
-		workload, options.Namespace, options.Image, getExchangeLabels(options.Labels, workload, app), options.Debug)
+	podIP, podName, sshcm, credential, err := kubernetes.GetOrCreateShadow(workload, options.Namespace, options.Image, getExchangeLabels(options.Labels, workload, app), options.Debug, false)
 	log.Info().Msgf("create exchange shadow %s in namespace %s", workload, options.Namespace)
 
 	if err != nil {

--- a/pkg/kt/command/mesh.go
+++ b/pkg/kt/command/mesh.go
@@ -59,7 +59,7 @@ func newMeshCommand(cli kt.CliInterface, options *options.DaemonOptions, action 
 func (action *Action) Mesh(mesh string, cli kt.CliInterface, options *options.DaemonOptions) error {
 	checkConnectRunning(options.RuntimeOptions.PidFile)
 
-	ch := SetUpCloseHandler(cli, options)
+	ch := SetUpCloseHandler(cli, options, "mesh")
 
 	kubernetes, err := cluster.Create(options.KubeConfig)
 	if err != nil {
@@ -75,7 +75,7 @@ func (action *Action) Mesh(mesh string, cli kt.CliInterface, options *options.Da
 	workload := app.GetObjectMeta().GetName() + "-kt-" + meshVersion
 
 	labels := getMeshLabels(workload, meshVersion, app, options)
-	podIP, podName, sshcm, credential, err := kubernetes.CreateShadow(workload, options.Namespace, options.Image, labels, options.Debug)
+	podIP, podName, sshcm, credential, err := kubernetes.GetOrCreateShadow(workload, options.Namespace, options.Image, labels, options.Debug, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/kt/command/run.go
+++ b/pkg/kt/command/run.go
@@ -46,7 +46,7 @@ func newRunCommand(cli kt.CliInterface, options *options.DaemonOptions, action A
 
 // Run create a new service in cluster
 func (action *Action) Run(service string, cli kt.CliInterface, options *options.DaemonOptions) error {
-	ch := SetUpCloseHandler(cli, options)
+	ch := SetUpCloseHandler(cli, options, "run")
 	run(service, cli, options)
 	<-ch
 	return nil
@@ -71,7 +71,7 @@ func run(service string, cli kt.CliInterface, options *options.DaemonOptions) er
 		labels[k] = v
 	}
 
-	podIP, podName, sshcm, credential, err := kubernetes.CreateShadow(service, options.Namespace, options.Image, labels, options.Debug)
+	podIP, podName, sshcm, credential, err := kubernetes.GetOrCreateShadow(service, options.Namespace, options.Image, labels, options.Debug, false)
 	if err != nil {
 		return err
 	}

--- a/pkg/kt/command/run_test.go
+++ b/pkg/kt/command/run_test.go
@@ -141,7 +141,7 @@ func Test_run(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			kubernetes.EXPECT().
-				CreateShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).
+				GetOrCreateShadow(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), false).Times(1).
 				Return(tt.args.shadowResponse.podIP, tt.args.shadowResponse.podName, tt.args.shadowResponse.sshcm, tt.args.shadowResponse.credential, tt.args.shadowResponse.err)
 			kubernetes.EXPECT().CreateService(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).Times(1).Return(tt.args.serviceResponse.service, tt.args.serviceResponse.err)
 			shadow.EXPECT().

--- a/pkg/kt/command/util.go
+++ b/pkg/kt/command/util.go
@@ -94,7 +94,7 @@ func CleanupWorkspace(cli kt.CliInterface, options *options.DaemonOptions, actio
 			if err != nil {
 				return
 			}
-			refCount := deployment.ObjectMeta.Labels[vars.RefCount]
+			refCount := deployment.ObjectMeta.Annotations[vars.RefCount]
 			if refCount == "1" {
 				shouldCleanSharedShadowResource = true
 				log.Info().Msgf("Shared shadow has only one ref, delete it")
@@ -105,7 +105,7 @@ func CleanupWorkspace(cli kt.CliInterface, options *options.DaemonOptions, actio
 				if err != nil {
 					return
 				}
-				deployment.ObjectMeta.Labels[vars.RefCount] = strconv.Itoa(count - 1)
+				deployment.ObjectMeta.Annotations[vars.RefCount] = strconv.Itoa(count - 1)
 				_, err = kubernetes.UpdateDeployment(options.Namespace, deployment)
 				if err != nil {
 					return

--- a/pkg/kt/command/util.go
+++ b/pkg/kt/command/util.go
@@ -44,7 +44,7 @@ func SetUpCloseHandler(cli kt.CliInterface, options *options.DaemonOptions, acti
 	go func() {
 		<-ch
 		log.Info().Msgf("- Terminal And Clean Workspace\n")
-		CleanupWorkspace(cli, options, action)
+		CleanupWorkspace(cli, options)
 		log.Info().Msgf("- Successful Clean Up Workspace\n")
 		os.Exit(0)
 	}()
@@ -52,7 +52,7 @@ func SetUpCloseHandler(cli kt.CliInterface, options *options.DaemonOptions, acti
 }
 
 // CleanupWorkspace clean workspace
-func CleanupWorkspace(cli kt.CliInterface, options *options.DaemonOptions, action string) {
+func CleanupWorkspace(cli kt.CliInterface, options *options.DaemonOptions) {
 	log.Info().Msgf("- start Clean Workspace\n")
 	if _, err := os.Stat(options.RuntimeOptions.PidFile); err == nil {
 		log.Info().Msgf("- remove pid %s", options.RuntimeOptions.PidFile)

--- a/pkg/kt/connect/outbound_test.go
+++ b/pkg/kt/connect/outbound_test.go
@@ -23,7 +23,9 @@ func TestShadow_Outbound(t *testing.T) {
 	sshuttle := sshuttle.NewMockCliInterface(ctl)
 	kubectl := kubectl.NewMockCliInterface(ctl)
 
-	kubectl.EXPECT().PortForward(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(exec.Command("echo", "kubectl portforward"))
+	kubectl.EXPECT().PortForward(gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().DoAndReturn(func(namespace, resource, remotePort interface{}) *exec.Cmd {
+		return exec.Command("echo", "kubectl portforward")
+	})
 	sshuttle.EXPECT().Connect(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(exec.Command("echo", "sshuttle conect"))
 	ssh.EXPECT().DynamicForwardLocalRequestToRemote(gomock.Any(), gomock.Any(), gomock.Any(), gomock.Any()).AnyTimes().Return(exec.Command("echo", "ssh dynamic forward"))
 

--- a/pkg/kt/exec/run.go
+++ b/pkg/kt/exec/run.go
@@ -19,7 +19,10 @@ func RunAndWait(cmd *exec.Cmd, name string, debug bool) (err error) {
 
 // BackgroundRun run cmd in background
 func BackgroundRun(cmd *exec.Cmd, name string, debug bool) (err error) {
-	runCmd(cmd, name, debug)
+	err = runCmd(cmd, name, debug)
+	if err != nil {
+		return
+	}
 	go func() {
 		err = cmd.Wait()
 		log.Info().Msgf("%s finished", name)

--- a/pkg/kt/exec/run.go
+++ b/pkg/kt/exec/run.go
@@ -19,10 +19,7 @@ func RunAndWait(cmd *exec.Cmd, name string, debug bool) (err error) {
 
 // BackgroundRun run cmd in background
 func BackgroundRun(cmd *exec.Cmd, name string, debug bool) (err error) {
-	err = runCmd(cmd, name, debug)
-	if err != nil {
-		return
-	}
+	runCmd(cmd, name, debug)
 	go func() {
 		err = cmd.Wait()
 		log.Info().Msgf("%s finished", name)

--- a/pkg/kt/exec/run.go
+++ b/pkg/kt/exec/run.go
@@ -19,9 +19,15 @@ func RunAndWait(cmd *exec.Cmd, name string, debug bool) (err error) {
 
 // BackgroundRun run cmd in background
 func BackgroundRun(cmd *exec.Cmd, name string, debug bool) (err error) {
-	runCmd(cmd, name, debug)
+	err = runCmd(cmd, name, debug)
+	if err != nil {
+		return
+	}
 	go func() {
 		err = cmd.Wait()
+		if err != nil {
+			return
+		}
 		log.Info().Msgf("%s finished", name)
 	}()
 	return

--- a/pkg/kt/options/options.go
+++ b/pkg/kt/options/options.go
@@ -20,6 +20,7 @@ type connectOptions struct {
 	Method      string
 	Dump2Hosts  bool
 	Hosts       map[string]string
+	ShareShadow bool
 }
 
 type exchangeOptions struct {

--- a/pkg/kt/util/ssh.go
+++ b/pkg/kt/util/ssh.go
@@ -28,9 +28,12 @@ type SSHGenerator struct {
 	PrivateKeyPath        string
 }
 
-func (g *SSHGenerator) UpdateKeys(privateKey string, publicKey string) {
-	g.PrivateKey = []byte(privateKey)
-	g.PublicKey = []byte(publicKey)
+func NewSSHGenerator(privateKey string, publicKey string, privateKeyPath string) *SSHGenerator {
+	return &SSHGenerator{
+		PrivateKey:     []byte(privateKey),
+		PublicKey:      []byte(publicKey),
+		PrivateKeyPath: privateKeyPath,
+	}
 }
 
 // NewDefaultSSHCredential ...

--- a/pkg/kt/util/ssh.go
+++ b/pkg/kt/util/ssh.go
@@ -28,6 +28,11 @@ type SSHGenerator struct {
 	PrivateKeyPath        string
 }
 
+func (g *SSHGenerator) UpdateKeys(privateKey string, publicKey string) {
+	g.PrivateKey = []byte(privateKey)
+	g.PublicKey = []byte(publicKey)
+}
+
 // NewDefaultSSHCredential ...
 func NewDefaultSSHCredential() *SSHCredential {
 	return &SSHCredential{
@@ -54,7 +59,7 @@ func Generate(privateKeyPath string) (*SSHGenerator, error) {
 		PrivateKeyPath: privateKeyPath,
 		PublicKey:      publicKeyBytes,
 	}
-	err = writePrivateKey(ssh.PrivateKeyPath, ssh.PrivateKey)
+	err = WritePrivateKey(ssh.PrivateKeyPath, ssh.PrivateKey)
 	return ssh, err
 }
 
@@ -112,8 +117,8 @@ func generatePublicKey(privatekey *rsa.PublicKey) ([]byte, error) {
 	return pubKeyBytes, nil
 }
 
-// writePrivateKey write ssh private key to privateKeyPath
-func writePrivateKey(privateKeyPath string, data []byte) error {
+// WritePrivateKey write ssh private key to privateKeyPath
+func WritePrivateKey(privateKeyPath string, data []byte) error {
 	dir := filepath.Dir(privateKeyPath)
 	if _, err := os.Stat(dir); os.IsNotExist(err) {
 		if err = os.MkdirAll(dir, 0700); err != nil {

--- a/pkg/kt/vars/vars.go
+++ b/pkg/kt/vars/vars.go
@@ -7,4 +7,5 @@ var (
 	SSHBitSize = 2048
 	// SSHAuthKey auth key name
 	SSHAuthKey = "authorized"
+	RefCount   = "refCount"
 )

--- a/pkg/kt/vars/vars.go
+++ b/pkg/kt/vars/vars.go
@@ -6,6 +6,7 @@ var (
 	// SSHBitSize ssh bit size
 	SSHBitSize = 2048
 	// SSHAuthKey auth key name
-	SSHAuthKey = "authorized"
-	RefCount   = "refCount"
+	SSHAuthKey        = "authorized"
+	SSHAuthPrivateKey = "privateKey"
+	RefCount          = "refCount"
 )


### PR DESCRIPTION
Only connect got affected.

1. If option is given, deployment name will be fixed as "kt-connect-daemon-connect-shared" instead of having random suffix
2. The shared shadow deployment will have a label named "refCount" to indicate how many clients are using it.
3. Store both public and private key in config map, so that latter clients can reuse it.
4. When client reuses the shadow, increase the refCount label value
5. When tear down, read the refCount label and decide to delete it or reduce the refCount.