### PR TITLE
dump2hosts改为输入namespace列表，用逗号分隔

### DIFF
--- a/pkg/kt/command/connect.go
+++ b/pkg/kt/command/connect.go
@@ -56,10 +56,15 @@ func newConnectCommand(options *options.DaemonOptions, action ActionInterface) c
 				Usage:       "Custom CIDR eq '172.2.0.0/16'",
 				Destination: &options.ConnectOptions.CIDR,
 			},
-			cli.StringFlag{
+			cli.BoolFlag{
 				Name:        "dump2hosts",
 				Usage:       "Auto write service to local hosts file",
 				Destination: &options.ConnectOptions.Dump2Hosts,
+			},
+			cli.StringSliceFlag{
+				Name:  "dump2hostsNS",
+				Usage: "Which namespaces service to local hosts file, support multiple namespaces.",
+				Value: &options.ConnectOptions.Dump2HostsNamespaces,
 			},
 		},
 		Action: func(c *cli.Context) error {
@@ -100,23 +105,28 @@ func (action *Action) Connect(options *options.DaemonOptions) (err error) {
 
 func connectToCluster(shadow connect.ShadowInterface, kubernetes cluster.KubernetesInterface, options *options.DaemonOptions) (err error) {
 
-	if options.ConnectOptions.Dump2Hosts != "" {
+	if options.ConnectOptions.Dump2Hosts {
+		log.Debug().Msgf("Serach service in %s namespace...", options.Namespace)
 		hosts := kubernetes.ServiceHosts(options.Namespace)
-
-		namespaces := strings.Split(options.ConnectOptions.Dump2Hosts, ",")
-		for _, namespace := range namespaces {
-			if namespace == options.Namespace {
-				continue
-			}
-			singleHosts := kubernetes.ServiceHosts(namespace)
-			for k, v := range singleHosts {
-				if v == "" || v == "None" {
+		for k, v := range hosts {
+			log.Debug().Msgf("Service found: %s %s", k, v)
+		}
+		if options.ConnectOptions.Dump2HostsNamespaces != nil {
+			for _, namespace := range options.ConnectOptions.Dump2HostsNamespaces {
+				if namespace == options.Namespace {
 					continue
 				}
-				hosts[k+"."+namespace] = v
+				log.Debug().Msgf("Serach service in %s namespace...", namespace)
+				singleHosts := kubernetes.ServiceHosts(namespace)
+				for k, v := range singleHosts {
+					if v == "" || v == "None" {
+						continue
+					}
+					log.Debug().Msgf("Service found: %s.%s %s", k, namespace, v)
+					hosts[k+"."+namespace] = v
+				}
 			}
 		}
-
 		util.DumpHosts(hosts)
 		options.ConnectOptions.Hosts = hosts
 	}

--- a/pkg/kt/options/options.go
+++ b/pkg/kt/options/options.go
@@ -17,7 +17,7 @@ type connectOptions struct {
 	Socke5Proxy int
 	CIDR        string
 	Method      string
-	Dump2Hosts  bool
+	Dump2Hosts  string
 	Hosts       map[string]string
 }
 

--- a/pkg/kt/options/options.go
+++ b/pkg/kt/options/options.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 
 	"github.com/alibaba/kt-connect/pkg/kt/util"
+	"github.com/urfave/cli"
 )
 
 type runOptions struct {
@@ -12,13 +13,14 @@ type runOptions struct {
 }
 
 type connectOptions struct {
-	DisableDNS  bool
-	SSHPort     int
-	Socke5Proxy int
-	CIDR        string
-	Method      string
-	Dump2Hosts  string
-	Hosts       map[string]string
+	DisableDNS           bool
+	SSHPort              int
+	Socke5Proxy          int
+	CIDR                 string
+	Method               string
+	Dump2Hosts           bool
+	Dump2HostsNamespaces cli.StringSlice
+	Hosts                map[string]string
 }
 
 type exchangeOptions struct {


### PR DESCRIPTION
Usage:

- 不加--dump2hosts参数时，与原来一样不写入本地hosts文件
- 加--dump2hosts时，将当前namespace的服务写入hosts文件
- 加--dump2hosts，再附加--dump2hostsNS参数时写入多个namespace的服务到hosts文件
```bash
# 此命令从default，db，redis三个命名空间收集service
ktctl connect --dump2hosts --dump2hostsNS db --dump2hostsNS redis
# 此命令从test，db，redis三个命名空间收集service
ktctl --namespace test connect --dump2hosts --dump2hostsNS db --dump2hostsNS redis
```
