### PR TITLE
实现命名空间权限用户可指定 cidr参数后正常使用

### DIFF
--- a/pkg/kt/cluster/kubernetes.go
+++ b/pkg/kt/cluster/kubernetes.go
@@ -273,8 +273,8 @@ func (k *Kubernetes) CreateService(name, namespace string, port int, labels map[
 }
 
 // ClusterCrids get cluster cirds
-func (k *Kubernetes) ClusterCrids(podCIDR string) (cidrs []string, err error) {
-	serviceList, err := k.Clientset.CoreV1().Services("").List(metav1.ListOptions{})
+func (k *Kubernetes) ClusterCrids(namespace string, podCIDR string) (cidrs []string, err error) {
+	serviceList, err := k.Clientset.CoreV1().Services(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return
 	}

--- a/pkg/kt/cluster/kubernetes_test.go
+++ b/pkg/kt/cluster/kubernetes_test.go
@@ -122,7 +122,7 @@ func TestKubernetes_ClusterCrids(t *testing.T) {
 			k := &Kubernetes{
 				Clientset: testclient.NewSimpleClientset(tt.objs...),
 			}
-			gotCidrs, err := k.ClusterCrids(tt.args.podCIDR)
+			gotCidrs, err := k.ClusterCrids("default", tt.args.podCIDR)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Kubernetes.ClusterCrids() error = %v, wantErr %v", err, tt.wantErr)
 				return

--- a/pkg/kt/cluster/types.go
+++ b/pkg/kt/cluster/types.go
@@ -34,7 +34,7 @@ type KubernetesInterface interface {
 	Scale(deployment *appV1.Deployment, replicas *int32) (err error)
 	ScaleTo(deployment, namespace string, replicas *int32) (err error)
 	ServiceHosts(namespace string) (hosts map[string]string)
-	ClusterCrids(podCIDR string) (cidrs []string, err error)
+	ClusterCrids(namespace string, podCIDR string) (cidrs []string, err error)
 	GetOrCreateShadow(name, namespace, image string, labels, envs map[string]string, debug, reuseShadow bool) (podIP, podName, sshcm string, credential *util.SSHCredential, err error)
 	CreateService(name, namespace string, port int, labels map[string]string) (*coreV1.Service, error)
 	GetDeployment(name string, namespace string) (*appV1.Deployment, error)

--- a/pkg/kt/command/connect.go
+++ b/pkg/kt/command/connect.go
@@ -2,10 +2,11 @@ package command
 
 import (
 	"fmt"
-	"github.com/alibaba/kt-connect/pkg/common"
-	"github.com/alibaba/kt-connect/pkg/kt/cluster"
 	"os"
 	"strings"
+
+	"github.com/alibaba/kt-connect/pkg/common"
+	"github.com/alibaba/kt-connect/pkg/kt/cluster"
 
 	"github.com/alibaba/kt-connect/pkg/kt"
 	"github.com/alibaba/kt-connect/pkg/kt/options"
@@ -75,7 +76,7 @@ func connectToCluster(cli kt.CliInterface, options *options.DaemonOptions) (err 
 		return
 	}
 
-	cidrs, err := kubernetes.ClusterCrids(options.ConnectOptions.CIDR)
+	cidrs, err := kubernetes.ClusterCrids(options.Namespace, options.ConnectOptions.CIDR)
 	if err != nil {
 		return
 	}


### PR DESCRIPTION
可以实现较低的权限，使用调试。

cidr 需要 get nodes 权限， 暂时使用参数指定了。