### PR TITLE
Fix custom registry not work

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,12 @@
 
 PREFIX			  ?= registry.cn-hangzhou.aliyuncs.com/rdc-incubator
-TAG				  ?= $(shell date +%s)
+TAG				  ?= $(shell git rev-parse --short HEAD)
 SHADOW_IMAGE	  =  kt-connect-shadow
 SHADOW_BASE_IMAGE =  shadow-base
 BUILDER_IMAGE	  =  builder
 DASHBOARD_IMAGE   =  kt-connect-dashboard
 SERVER_IMAGE	  =  kt-connect-server
+GO_BUILD_LDFLAGS  =  -X main.version=$(TAG) -X main.hub=$(PREFIX)
 
 # generate mock
 generate-mock:
@@ -37,8 +38,8 @@ check:
 
 # build ktctl
 build-connect:
-	scripts/build-ktctl
-	scripts/archive
+	GO_BUILD_LDFLAGS="$(GO_BUILD_LDFLAGS)" scripts/build-ktctl
+	GO_BUILD_LDFLAGS="$(GO_BUILD_LDFLAGS)" scripts/archive
 
 # build connect plugin
 build-connect-plugin:

--- a/cmd/ktctl/main.go
+++ b/cmd/ktctl/main.go
@@ -16,7 +16,8 @@ import (
 )
 
 var (
-	version = "dev"
+	version string // Will be injected when building
+	hub     string // Will be injected when building
 )
 
 func init() {
@@ -32,7 +33,7 @@ func main() {
 	app.Usage = ""
 	app.Version = version
 	app.Authors = command.NewCliAuthor()
-	app.Flags = command.AppFlags(options, version)
+	app.Flags = command.AppFlags(options, hub, version)
 
 	context := &kt.Cli{Options: options}
 	action := command.Action{}

--- a/pkg/kt/command/flags.go
+++ b/pkg/kt/command/flags.go
@@ -1,13 +1,15 @@
 package command
 
 import (
+	"fmt"
+
 	"github.com/alibaba/kt-connect/pkg/kt/options"
 	"github.com/alibaba/kt-connect/pkg/kt/util"
 	"github.com/urfave/cli"
 )
 
 // AppFlags return app flags
-func AppFlags(options *options.DaemonOptions, version string) []cli.Flag {
+func AppFlags(options *options.DaemonOptions, hub, version string) []cli.Flag {
 	return []cli.Flag{
 		cli.StringFlag{
 			Name:        "namespace,n",
@@ -22,7 +24,7 @@ func AppFlags(options *options.DaemonOptions, version string) []cli.Flag {
 		cli.StringFlag{
 			Name:        "image,i",
 			Usage:       "Custom proxy image",
-			Value:       "registry.cn-hangzhou.aliyuncs.com/rdc-incubator/kt-connect-shadow:v" + version,
+			Value:       fmt.Sprintf("%v/kt-connect-shadow:%v", hub, version),
 			Destination: &options.Image,
 		},
 		cli.BoolFlag{

--- a/scripts/build-ktctl
+++ b/scripts/build-ktctl
@@ -1,8 +1,8 @@
 #!/bin/bash
 export GO111MODULE on
-GOARCH=amd64 GOOS=linux go build -o "artifacts/ktctl/ktctl_linux_amd64" ./cmd/ktctl
-GOARCH=386 GOOS=linux go build -o "artifacts/ktctl/ktctl_linux_386" ./cmd/ktctl
-GOARCH=amd64 GOOS=darwin go build -o "artifacts/ktctl/ktctl_darwin_amd64" ./cmd/ktctl
-GOARCH=386 GOOS=darwin go build -o "artifacts/ktctl/ktctl_darwin_386" ./cmd/ktctl
-GOARCH=386 GOOS=windows go build -o "artifacts/ktctl/ktctl_windows_386.exe" ./cmd/ktctl
-GOARCH=amd64 GOOS=windows go build -o "artifacts/ktctl/ktctl_windows_amd64.exe" ./cmd/ktctl
+GOARCH=amd64 GOOS=linux go build -ldflags "${GO_BUILD_LDFLAGS}" -o "artifacts/ktctl/ktctl_linux_amd64" ./cmd/ktctl
+GOARCH=386 GOOS=linux go build -ldflags "${GO_BUILD_LDFLAGS}" -o "artifacts/ktctl/ktctl_linux_386" ./cmd/ktctl
+GOARCH=amd64 GOOS=darwin go build -ldflags "${GO_BUILD_LDFLAGS}" -o "artifacts/ktctl/ktctl_darwin_amd64" ./cmd/ktctl
+GOARCH=386 GOOS=darwin go build -ldflags "${GO_BUILD_LDFLAGS}" -o "artifacts/ktctl/ktctl_darwin_386" ./cmd/ktctl
+GOARCH=386 GOOS=windows go build -ldflags "${GO_BUILD_LDFLAGS}" -o "artifacts/ktctl/ktctl_windows_386.exe" ./cmd/ktctl
+GOARCH=amd64 GOOS=windows go build -ldflags "${GO_BUILD_LDFLAGS}" -o "artifacts/ktctl/ktctl_windows_amd64.exe" ./cmd/ktctl


### PR DESCRIPTION
The `PREFIX` in `Makefile` takes no effect at all, and the `TAG` take the timestamp as its default value, which changes between `make build` and `make release-shadow`