### PR TITLE
doc:Fix document path error

### DIFF
--- a/docs/zh-cn/coverpage.md
+++ b/docs/zh-cn/coverpage.md
@@ -8,4 +8,4 @@
 -（使用KT双向通道）
 
 [Github](https://github.com/alibaba/kt-connect)
-[快速开始](zh-cn/quickstart)
+[快速开始](zh-cn/guide/quickstart)


### PR DESCRIPTION
【快速开始】button wrong path, “404 - Not found” after jump.