### PR TITLE
doc: fix typo in quickstart

### DIFF
--- a/docs/zh-cn/guide/quickstart.md
+++ b/docs/zh-cn/guide/quickstart.md
@@ -160,7 +160,7 @@ Mesh命令有两种运行模式，默认的`auto`模式不需要额外的服务�
 ```bash
 $ kubectl exec deployment/tomcat -c tomcat -- /bin/bash -c 'mkdir webapps/ROOT; echo "kt-connect demo v1" > webapps/ROOT/index.html'
 
-$ ktctl mesh tomcat --expose 8080 --mode auto
+$ ktctl mesh tomcat --expose 8080
 00:00AM INF KtConnect start at <PID>
 ... ...
 --------------------------------------------------------------

--- a/docs/zh-cn/guide/quickstart.md
+++ b/docs/zh-cn/guide/quickstart.md
@@ -160,7 +160,7 @@ Mesh命令有两种运行模式，默认的`auto`模式不需要额外的服务�
 ```bash
 $ kubectl exec deployment/tomcat -c tomcat -- /bin/bash -c 'mkdir webapps/ROOT; echo "kt-connect demo v1" > webapps/ROOT/index.html'
 
-$ ktctl mesh tomcat --expose 8080 --method auto
+$ ktctl mesh tomcat --expose 8080 --mode auto
 00:00AM INF KtConnect start at <PID>
 ... ...
 --------------------------------------------------------------


### PR DESCRIPTION
In `mesh` command, `method` option should be `mode` now.  and it would be better to simplify like what en-us doc done. 