### PR TITLE
allow specify port name prefix for preview

### DIFF
--- a/pkg/kt/command/options/options.go
+++ b/pkg/kt/command/options/options.go
@@ -56,6 +56,7 @@ type PreviewOptions struct {
 	External         bool
 	Expose           string
 	SkipPortChecking bool
+	PortNamePrefix   string
 }
 
 // ForwardOptions ...

--- a/pkg/kt/command/options/preview.go
+++ b/pkg/kt/command/options/preview.go
@@ -18,6 +18,11 @@ func PreviewFlags() []OptionConfig {
 			DefaultValue: false,
 			Description:  "Do not check whether specified local ports are listened",
 		},
+		{
+			Target:       "PortNamePrefix",
+			DefaultValue: "kt-",
+			Description:  "Customize the port name prefix",
+		},
 	}
 	return flags
 }

--- a/pkg/kt/command/preview/expose.go
+++ b/pkg/kt/command/preview/expose.go
@@ -15,8 +15,8 @@ func Expose(serviceName string) error {
 	version := strings.ToLower(util.RandomString(5))
 	shadowPodName := fmt.Sprintf("%s-kt-%s", serviceName, version)
 	labels := map[string]string{
-		util.KtRole:    util.RolePreviewShadow,
-		util.KtTarget:  util.RandomString(20),
+		util.KtRole:   util.RolePreviewShadow,
+		util.KtTarget: util.RandomString(20),
 	}
 	annotations := map[string]string{
 		util.KtConfig: fmt.Sprintf("service=%s", serviceName),
@@ -53,9 +53,10 @@ func exposeLocalService(serviceName, shadowPodName string, labels, annotations m
 			Labels:      map[string]string{},
 			Annotations: map[string]string{},
 		},
-		External:  opt.Get().Preview.External,
-		Ports:     ports,
-		Selectors: labels,
+		External:       opt.Get().Preview.External,
+		Ports:          ports,
+		Selectors:      labels,
+		PortNamePrefix: opt.Get().Preview.PortNamePrefix,
 	}); err != nil {
 		return err
 	}

--- a/pkg/kt/service/cluster/helper.go
+++ b/pkg/kt/service/cluster/helper.go
@@ -26,9 +26,14 @@ func createService(metaAndSpec *SvcMetaAndSpec) *coreV1.Service {
 	metaAndSpec.Meta.Annotations = util.MapPut(metaAndSpec.Meta.Annotations, util.KtLastHeartBeat, util.GetTimestamp())
 	metaAndSpec.Meta.Labels = util.MergeMap(metaAndSpec.Meta.Labels, map[string]string{util.ControlBy: util.KubernetesToolkit})
 
+	portNamePrefix := metaAndSpec.PortNamePrefix
+	if portNamePrefix == "" {
+		portNamePrefix = "kt-"
+	}
+
 	for srcPort, targetPort := range metaAndSpec.Ports {
 		servicePorts = append(servicePorts, coreV1.ServicePort{
-			Name:       fmt.Sprintf("kt-%d", srcPort),
+			Name:       fmt.Sprintf("%s%d", portNamePrefix, srcPort),
 			Port:       int32(srcPort),
 			TargetPort: intstr.FromInt(targetPort),
 		})
@@ -141,7 +146,7 @@ func createContainer(image string, args []string, envs map[string]string, ports 
 		},
 		Ports: []coreV1.ContainerPort{},
 		Resources: coreV1.ResourceRequirements{
-			Limits: coreV1.ResourceList{},
+			Limits:   coreV1.ResourceList{},
 			Requests: coreV1.ResourceList{},
 		},
 	}
@@ -150,8 +155,8 @@ func createContainer(image string, args []string, envs map[string]string, ports 
 	}
 	for name, port := range ports {
 		container.Ports = append(container.Ports, coreV1.ContainerPort{
-			Name: name,
-			Protocol: coreV1.ProtocolTCP,
+			Name:          name,
+			Protocol:      coreV1.ProtocolTCP,
 			ContainerPort: int32(port),
 		})
 	}

--- a/pkg/kt/service/cluster/service.go
+++ b/pkg/kt/service/cluster/service.go
@@ -12,10 +12,11 @@ import (
 
 // SvcMetaAndSpec ...
 type SvcMetaAndSpec struct {
-	Meta      *ResourceMeta
-	External  bool
-	Ports     map[int]int
-	Selectors map[string]string
+	Meta           *ResourceMeta
+	External       bool
+	Ports          map[int]int
+	Selectors      map[string]string
+	PortNamePrefix string
 }
 
 // GetService get service


### PR DESCRIPTION
This feature is required for istio [Protocol Selection](https://istio.io/latest/docs/ops/configuration/traffic-management/protocol-selection/#explicit-protocol-selection).

A port name prefix or even a full port name should be associated with each port individually. But the `--expose` option is widely used. So I added a separate parameter `-portNamePrefix` to handle it.