### PR TITLE
fix: Increase client_max_body_size to support large file uploads

### DIFF
--- a/pkg/router/route.conf
+++ b/pkg/router/route.conf
@@ -37,6 +37,7 @@ server {
     location / {
         proxy_redirect off;
         proxy_http_version 1.1;
+        client_max_body_size 1000M;
 
     {{range $version := $.Versions}}
         if ($http_{{$.Header}} = "{{$version}}") {


### PR DESCRIPTION
This PR modifies the NGINX configuration template (`pkg/router/route.conf`) to support larger file uploads by adding:  
```nginx
client_max_body_size 1000m;
```

Changes:  
• Added `client_max_body_size 1000m;` directive to the NGINX router configuration  

• This allows file uploads up to 1000MB (1GB) through kt-connect  


Context:  
The default NGINX client_max_body_size (typically 1m) was insufficient for file transfer use cases. This change enables:  
• Reliable transfer of medium/large files  

• Better compatibility with file upload requirements  

• Maintains existing security constraints while increasing practical limits  


Testing:  
• [x] Verified file uploads up to 1000MB work correctly  

• [x] Confirmed existing functionality remains unaffected  

• [x] Tested with both HTTP and HTTPS connections  


Impact:  
• Improves file transfer capabilities without requiring client-side changes  

• Backward compatible with all existing deployments  


Additional Notes:  
The 1000m limit can be adjusted in future if needed by modifying this configuration value.